### PR TITLE
section names prefixed with "profile"

### DIFF
--- a/src/awsudo/profile.rs
+++ b/src/awsudo/profile.rs
@@ -20,9 +20,10 @@ impl PartialEq for Profile {
 
 impl Profile {
     pub fn load_from(file_path: String, user: String) -> Result<Profile, &'static str> {
+        let profile = format!("profile {}", user);
         match Ini::load_from_file(Path::new(&file_path)) {
             Err(_) => Err("Profile file not found"),
-            Ok(ini) => match ini.section(Some(user.to_owned())) {
+            Ok(ini) => match ini.section(Some(profile.to_owned())) {
                 Some(s) => match (s.get("role_arn"), s.get("mfa_serial"), s.get("region")) {
                     (None, _, _) => Err("Profile role_arn not found"),
                     (Some(role_arn), mfa, region) => Ok(Profile {

--- a/test/fixtures/config/missing_values
+++ b/test/fixtures/config/missing_values
@@ -1,12 +1,12 @@
-[missing_arn]
+[profile missing_arn]
 foo=1
 region=eu-central-2
 mfa_serial=210418
 
-[missing_mfa]
+[profile missing_mfa]
 role_arn=example-arn
 region=us-east-1
 
-[missing_region]
+[profile missing_region]
 role_arn=example-arn
 mfa_serial=example-mfa

--- a/test/fixtures/config/multi_profile
+++ b/test/fixtures/config/multi_profile
@@ -1,4 +1,4 @@
-[complete]
+[profile complete]
 role_arn=example-arn
 mfa_serial=example-mfa
 region=us-east-1


### PR DESCRIPTION
According to the docs(*) (and the behavior of the aws-cli tool), the profiles,
ie. the section names in the ~/.aws/config file should be prefixed with "profile",
for example:

```
[profile user1]
region=us-east-1
output=text
```

while awsudo, expects it to be just `[user1]`.

  * https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html