### PR TITLE
prefer runtime_dir instead of home_dir for cached credentials

### DIFF
--- a/src/awsudo/cache.rs
+++ b/src/awsudo/cache.rs
@@ -97,22 +97,22 @@ mod tests {
     use std::fs;
     use std::path::{Path, PathBuf};
 
-    fn fixtures_tmp_path() -> String {
+    fn fixtures_tmp_path() -> PathBuf {
         let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         p.push("test/fixtures/tmp/cache");
-        p.to_str().unwrap().to_string()
+        p
     }
 
-    fn fixtures_path() -> String {
+    fn fixtures_path() -> PathBuf {
         let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         p.push("test/fixtures/cache");
-        p.to_str().unwrap().to_string()
+        p
     }
 
     #[test]
     fn it_returns_error_when_the_file_is_not_present() {
         assert_eq!(
-            Cache::new(fixtures_path(), "path".to_string()).fetch(),
+            Cache::new(fixtures_path(), "path").fetch(),
             Err("Cache file is not present or not valid")
         );
     }
@@ -120,7 +120,7 @@ mod tests {
     #[test]
     fn it_returns_error_when_the_file_is_not_ini_valid() {
         assert_eq!(
-            Cache::new(fixtures_path(), "invalid".to_string()).fetch(),
+            Cache::new(fixtures_path(), "invalid").fetch(),
             Err("Cache file is missing required values")
         );
     }
@@ -128,7 +128,7 @@ mod tests {
     #[test]
     fn it_returns_error_when_the_file_is_missing_values_valid() {
         assert_eq!(
-            Cache::new(fixtures_path(), "invalid_missing_values".to_string()).fetch(),
+            Cache::new(fixtures_path(), "invalid_missing_values").fetch(),
             Err("Cache file is missing required values")
         );
     }
@@ -136,7 +136,7 @@ mod tests {
     #[test]
     fn it_returns_error_when_the_file_date_is_not_valid() {
         assert_eq!(
-            Cache::new(fixtures_path(), "invalid_date".to_string()).fetch(),
+            Cache::new(fixtures_path(), "invalid_date").fetch(),
             Err("Cache file does not have a valid date")
         );
     }
@@ -144,7 +144,7 @@ mod tests {
     #[test]
     fn it_returns_error_when_the_file_date_is_expired() {
         assert_eq!(
-            Cache::new(fixtures_path(), "invalid_expired".to_string()).fetch(),
+            Cache::new(fixtures_path(), "invalid_expired").fetch(),
             Err("Cache file is expired")
         );
     }
@@ -152,7 +152,7 @@ mod tests {
     #[test]
     fn it_returns_the_credentails_when_the_valid() {
         assert_eq!(
-            Cache::new(fixtures_path(), "valid".to_string()).fetch(),
+            Cache::new(fixtures_path(), "valid").fetch(),
             Ok(Credentials {
                 access_key_id: "ASIA3NOTVALID2WN5".to_string(),
                 secret_access_key: "8s7k+21mKladUU9d".to_string(),
@@ -172,7 +172,7 @@ mod tests {
         };
 
         assert_eq!(
-            Cache::new(fixtures_tmp_path(), "it-doesnt-matter".to_string()).persist(cr),
+            Cache::new(fixtures_tmp_path(), "it-doesnt-matter").persist(cr),
             Ok(()),
         );
     }
@@ -187,7 +187,7 @@ mod tests {
         };
 
         assert_eq!(
-            Cache::new("/invalid".to_string(), "it-doesnt-matter".to_string()).persist(cr),
+            Cache::new(PathBuf::from("/invalid"), "it-doesnt-matter").persist(cr),
             Err("Failed to persist cache: dir cannot be created"),
         );
     }
@@ -202,7 +202,7 @@ mod tests {
         };
 
         assert_eq!(
-            Cache::new(fixtures_tmp_path(), "file".to_string()).persist(cr),
+            Cache::new(fixtures_tmp_path(), "file").persist(cr),
             Ok(()),
         );
 

--- a/src/awsudo/cli.rs
+++ b/src/awsudo/cli.rs
@@ -28,16 +28,15 @@ fn from_args(matches: ArgMatches) -> CLI {
             None => panic!("Something wrong with your home dir"),
         },
     };
-    let cache_dir: String = match matches.value_of("cache_dir") {
-        Some(value) => String::from(value),
-        None => match dirs::home_dir() {
-            Some(path) => match path.join(AWS_DEFAULT_CACHE_DIR).to_str() {
-                Some(s) => String::from(s),
-                None => panic!("Something wrong with your home dir"),
-            },
-            None => panic!("Something wrong with your home dir"),
-        },
-    };
+    let cache_dir = matches.value_of("cache_dir")
+        .map(|s| std::path::PathBuf::from(s))
+        .or(dirs::runtime_dir().map(|path| path.join(AWS_DEFAULT_CACHE_DIR)))
+        .or(dirs::home_dir().map(|path| path.join(AWS_DEFAULT_CACHE_DIR)))
+        .expect("Something wrong with cache_dir")
+        .to_str()
+        .map(|s| s.to_owned())
+        .expect("Illegal utf-8 in cache_dir");
+
     let command = match matches.subcommand() {
         (external, maybe_matches) => {
             let args = match maybe_matches {

--- a/src/awsudo/cli.rs
+++ b/src/awsudo/cli.rs
@@ -9,7 +9,7 @@ pub struct CLI {
     pub user: String,
     pub command: String,
     pub config: String,
-    pub cache_dir: String,
+    pub cache_dir: std::path::PathBuf,
 }
 
 pub fn parse() -> CLI {
@@ -32,10 +32,7 @@ fn from_args(matches: ArgMatches) -> CLI {
         .map(|s| std::path::PathBuf::from(s))
         .or(dirs::runtime_dir().map(|path| path.join(AWS_DEFAULT_CACHE_DIR)))
         .or(dirs::home_dir().map(|path| path.join(AWS_DEFAULT_CACHE_DIR)))
-        .expect("Something wrong with cache_dir")
-        .to_str()
-        .map(|s| s.to_owned())
-        .expect("Illegal utf-8 in cache_dir");
+        .expect("Something wrong with cache_dir");
 
     let command = match matches.subcommand() {
         (external, maybe_matches) => {

--- a/src/awsudo/cli.rs
+++ b/src/awsudo/cli.rs
@@ -8,7 +8,7 @@ const AWS_DEFAULT_CACHE_DIR: &str = ".awsudo/";
 pub struct CLI {
     pub user: String,
     pub command: String,
-    pub config: String,
+    pub config: std::path::PathBuf,
     pub cache_dir: std::path::PathBuf,
 }
 
@@ -18,16 +18,11 @@ pub fn parse() -> CLI {
 
 fn from_args(matches: ArgMatches) -> CLI {
     let user = String::from(matches.value_of("user").unwrap_or("default"));
-    let config: String = match matches.value_of("config") {
-        Some(value) => String::from(value),
-        None => match dirs::home_dir() {
-            Some(path) => match path.join(AWS_DEFAULT_CONFIG_PATH).to_str() {
-                Some(s) => String::from(s),
-                None => panic!("Something wrong with your home dir"),
-            },
-            None => panic!("Something wrong with your home dir"),
-        },
-    };
+    let config = matches.value_of("config")
+        .map(|s| std::path::PathBuf::from(s))
+        .or(dirs::home_dir().map(|path| path.join(AWS_DEFAULT_CONFIG_PATH)))
+        .expect("Something wrong with config");
+
     let cache_dir = matches.value_of("cache_dir")
         .map(|s| std::path::PathBuf::from(s))
         .or(dirs::runtime_dir().map(|path| path.join(AWS_DEFAULT_CACHE_DIR)))

--- a/src/awsudo/cli.rs
+++ b/src/awsudo/cli.rs
@@ -83,6 +83,7 @@ fn default<'b, 'c>() -> App<'b, 'c> {
 #[cfg(test)]
 mod tests {
     use awsudo::cli;
+    use std::path::PathBuf;
 
     #[test]
     fn it_parses_user() {
@@ -100,8 +101,6 @@ mod tests {
             dirs::home_dir()
                 .unwrap()
                 .join(".aws/config")
-                .to_str()
-                .unwrap()
         );
     }
 
@@ -111,7 +110,7 @@ mod tests {
 
         assert_eq!(
             result.cache_dir,
-            dirs::home_dir().unwrap().join(".awsudo/").to_str().unwrap()
+            dirs::runtime_dir().unwrap().join(".awsudo/")
         );
     }
 
@@ -125,7 +124,7 @@ mod tests {
             "/usr/specific/path",
         ]));
 
-        assert_eq!(result.config, "/usr/specific/path");
+        assert_eq!(result.config, PathBuf::from("/usr/specific/path"));
     }
 
     #[test]

--- a/src/awsudo/profile.rs
+++ b/src/awsudo/profile.rs
@@ -49,11 +49,11 @@ mod tests {
     use awsudo::profile::Profile;
     use std::path::PathBuf;
 
-    fn fixtures_path(file: &str) -> String {
+    fn fixtures_path(file: &str) -> PathBuf {
         let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         p.push("test/fixtures/config/");
         p.push(file);
-        p.to_str().unwrap().to_string()
+        p
     }
 
     #[test]

--- a/src/awsudo/profile.rs
+++ b/src/awsudo/profile.rs
@@ -1,7 +1,7 @@
 extern crate ini;
 
 use self::ini::Ini;
-use std::path::Path;
+use std::path::PathBuf;
 
 #[derive(Debug)]
 pub struct Profile {
@@ -19,9 +19,9 @@ impl PartialEq for Profile {
 }
 
 impl Profile {
-    pub fn load_from(file_path: String, user: String) -> Result<Profile, &'static str> {
+    pub fn load_from(file_path: PathBuf, user: String) -> Result<Profile, &'static str> {
         let profile = format!("profile {}", user);
-        match Ini::load_from_file(Path::new(&file_path)) {
+        match Ini::load_from_file(&file_path) {
             Err(_) => Err("Profile file not found"),
             Ok(ini) => match ini.section(Some(profile.to_owned())) {
                 Some(s) => match (s.get("role_arn"), s.get("mfa_serial"), s.get("region")) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ fn main() {
 
     // Get Credentials to be injected
     // First, try to get credentials from Cache
-    let cache = Cache::new(args.cache_dir.clone(), args.user.clone());
+    let cache = Cache::new(args.cache_dir, &args.user);
     let credentials = match cache.fetch() {
         Ok(credentials) => credentials,
         Err(_) => {


### PR DESCRIPTION
runtime_dir is in RAM on most (linux) systems, so is better suited for
temporary credentials.